### PR TITLE
Build docs only for changed files

### DIFF
--- a/lint-staged.config.js
+++ b/lint-staged.config.js
@@ -1,4 +1,8 @@
 module.exports = {
   "**/*.{css,html,json,md,yaml,yml}": ["prettier --write"],
-  "**/*.{ts}": ["prettier --write", "eslint --cache --ext '.js,.ts' --fix"],
+  "**/*.{ts}": [
+    "prettier --write",
+    "eslint --cache --ext '.js,.ts' --fix",
+    "./node_modules/.bin/typedoc ./src/types/ol-mapbox-style.d.ts ./src/types/olext.d.ts",
+  ],
 }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   },
   "husky": {
     "hooks": {
-      "pre-commit": "./node_modules/.bin/typedoc && git add docs/api && npm run tsc && lint-staged && npm run test"
+      "pre-commit": "npm run tsc && lint-staged && npm run test"
     }
   },
   "dependencies": {


### PR DESCRIPTION
Before this every commit was full of changed docs wherea a single id was
different.