### PR TITLE
Remove browser tests in ubuntu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,12 +69,12 @@ jobs:
           - os: windows-latest
             brwoser: chromium:headless
 
-          - os: ubuntu-latest
-            browser: firefox:headless
-          - os: ubuntu-latest
-            browser: chrome:headless
-          - os: ubuntu-latest
-            brwoser: chromium:headless
+          # - os: ubuntu-latest
+          #   browser: firefox:headless
+          # - os: ubuntu-latest
+          #   browser: chrome:headless
+          # - os: ubuntu-latest
+          #   browser: chromium:headless
 
           # Enable these once testcafe works on github's macos machines
           # - os: macos-latest


### PR DESCRIPTION
For some reason they no longer work but I cannot reproduce it on my local machine. Maybe it's something about the github VMs used for actions